### PR TITLE
解决学生页面无法正常加载

### DIFF
--- a/cloudfunctions/login/index.js
+++ b/cloudfunctions/login/index.js
@@ -5,7 +5,7 @@ const db = cloud.database()
 
 exports.main = async (event, context) => {
   const wxContext = cloud.getWXContext()
-  const { name, phone } = event
+  const { name='注意！程序可能有漏洞', phone = '请联系开发者！'} = event
 
   // 先查是否已有当前 openid
   const userRes = await db.collection('people').where({
@@ -13,7 +13,7 @@ exports.main = async (event, context) => {
   }).get()
 
   if (userRes.data.length > 0) {
-    return { role: userRes.data[0].role }
+    return { role: userRes.data[0].role, opendid: userRes.data[0]._openid }
   }
 
   // 查是否已有任何用户

--- a/cloudfunctions/login/index.js
+++ b/cloudfunctions/login/index.js
@@ -13,7 +13,7 @@ exports.main = async (event, context) => {
   }).get()
 
   if (userRes.data.length > 0) {
-    return { role: userRes.data[0].role, opendid: userRes.data[0]._openid }
+    return { role: userRes.data[0].role, openid: userRes.data[0]._openid }
   }
 
   // 查是否已有任何用户


### PR DESCRIPTION
当使用openid查询时，额外返回openid（使用姓名和电话查询时则不会），以解决学生端的加载问题。（潜在的问题：如果不登陆直接加载学生端，可能会额外添加学生）